### PR TITLE
Jwt vars kebab

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v5
       - name: Set up Java temurin 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Java temurin 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/core/src/main/java/fi/poltsi/vempain/auth/security/jwt/JwtUtils.java
+++ b/core/src/main/java/fi/poltsi/vempain/auth/security/jwt/JwtUtils.java
@@ -23,10 +23,10 @@ import java.util.UUID;
 @Component
 public class JwtUtils {
 
-	@Value("${vempain.app.jwtExpirationMs}")
+	@Value("${vempain.app.jwt-expiration-ms}")
 	private       long      jwtExpirationMs;
 	// TODO This needs to be cleaned up as the secret is not used at all for the moment
-	@Value("${vempain.app.jwtSecret}")
+	@Value("${vempain.app.jwt-secret}")
 	private       String    jwtSecret;
 	private final SecretKey secretKey = Jwts.SIG.HS512.key().build();
 

--- a/core/src/test/resources/application.yaml
+++ b/core/src/test/resources/application.yaml
@@ -24,5 +24,5 @@ vempain:
     max-age: 3600
   app:
     frontend-url: override-me
-    jwtSecret: override-me
-    jwtExpirationMs: 86400000
+    jwt-secret: override-me
+    jwt-expiration-ms: 86400000


### PR DESCRIPTION
This pull request updates configuration property naming conventions and upgrades a GitHub Actions dependency version for Java setup. The main changes are focused on standardizing property names to use kebab-case and ensuring the CI workflow uses the latest version of the Java setup action.

**Configuration property naming standardization:**

* Updated property names in `JwtUtils.java` to use kebab-case (`jwt-expiration-ms`, `jwt-secret`) instead of camelCase, aligning with the naming convention in configuration files.
* Changed the corresponding property names in `application.yaml` to kebab-case for consistency (`jwt-secret`, `jwt-expiration-ms`).

**CI workflow dependency update:**

* Upgraded the `actions/setup-java` version from v4 to v5 in `.github/workflows/ci.yaml` for both job steps, ensuring the workflow uses the latest features and security updates. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL20-R20) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL36-R36)