### PR TITLE
Update dependency versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,20 +1,20 @@
 releaseVersion=0.0.1-SNAPSHOT
 javaVersion=25
 # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot
-springBootVersion=4.0.2
-# https://mvnrepository.com/artifact/org.flywaydb/flyway-core
-flywayVersion=11.20.2
+springBootVersion=4.0.5
 # https://mvnrepository.com/artifact/org.testcontainers/testcontainers
-testContainersVersion=2.0.3
+testContainersVersion=2.0.4
 # https://mvnrepository.com/artifact/io.freefair.lombok/io.freefair.lombok.gradle.plugin
 ioFreeFairLombok=9.2.0
+# https://mvnrepository.com/artifact/org.postgresql/postgresql
+postgresqlVersion=42.7.10
 # https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
 jjwtVersion=0.13.0
 # https://mvnrepository.com/artifact/org.junit/junit-bom
-junitVersion=6.0.2
+junitVersion=6.0.3
 # https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations
-swaggerVersion=2.2.42
-# https://mvnrepository.com/artifact/org.postgresql/postgresql
-postgresqlVersion=42.7.9
+swaggerVersion=2.2.45
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
-mockitoVersion=5.21.0
+mockitoVersion=5.23.0
+# https://mvnrepository.com/artifact/org.flywaydb/flyway-core
+flywayVersion=11.20.2


### PR DESCRIPTION
This pull request updates several dependency versions in the `gradle.properties` file to ensure the project uses the latest compatible libraries and tools. The main focus is on keeping Spring Boot, Testcontainers, PostgreSQL, JUnit, Swagger, and Mockito up to date, along with a minor reordering of the Flyway version property.

Dependency version updates:

* Upgraded `springBootVersion` from 4.0.2 to 4.0.5, `testContainersVersion` from 2.0.3 to 2.0.4, `postgresqlVersion` from 42.7.9 to 42.7.10, `junitVersion` from 6.0.2 to 6.0.3, `swaggerVersion` from 2.2.42 to 2.2.45, and `mockitoVersion` from 5.21.0 to 5.23.0.

Other changes:

* Moved the Flyway version property (`flywayVersion=11.20.2`) further down in the file, but the version itself remains unchanged.